### PR TITLE
Update web interface with "Start Analysis" Button

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,7 @@ def autoindex(path='.'):
 def start_analyses():
 
     if not os.path.exists('/home/vagrant/myconnectome/.started'):
-        p = Popen(['/home/vagrant/miniconda/bin/python', '/home/vagrant/myconnectome/myconnectome/scripts/run_everything.py']
+        p = Popen(['/home/vagrant/miniconda/bin/python', '/home/vagrant/myconnectome/myconnectome/scripts/run_everything.py'],
                    stdout=open('/home/vagrant/myconnectome/myconnectome_job.log', 'w'),
                    stderr=open('/home/vagrant/myconnectome/myconnectome_job.err', 'a'),
                    preexec_fn=os.setpgrp,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -131,14 +131,14 @@ def show_analyses():
     meta_context,counter = create_context(meta_files,counter)
 
     # The counter determines if we've finished running analyses
-    analysis_status = 'Analyses Are Running'
+    analysis_status = 'Analysis is Running'
     if counter == number_analyses:
         analysis_status = 'Analysis Complete'
 
     return render_template('index.html',timeseries_context=timeseries_context,
                                         rna_context=rna_context,
                                         meta_context=meta_context,
-                                        startbutton=startbutton,
+                                        start_button=start_button,
                                         analysis_status=analysis_status)
 
 def create_context(link_dict,counter):
@@ -197,7 +197,7 @@ if ! [ -f /var/www/templates/index.html ]; then
     <div class='logo_box'><h1>MyConnectome<br/>Analyses</h1>
     <!-- Analysis Start Button-->
     {% if start_button %}
-        <a class='btn btn-default' href='/start' style='left: 40px;bottom: 140px; position:absolute' role='button'>Start Analyses</a>
+        <a class='btn btn-default' href='/start' style='left: 40px;bottom: 140px; position:absolute' role='button'>Start Analysis</a>
     {% else %}
         <a class='btn btn-default' href='#' style='left: 40px;bottom: 140px; position:absolute'; role='button' disabled>{{ analysis_status }}</a>
     {% endif %}

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,52 +90,28 @@ index = AutoIndex(app, browse_root='/var/www/results',add_url_rules=False)
 def autoindex(path='.'):
     return index.render_autoindex(path)
 
-
-@app.route('/start')
-def start_analyses():
-
-    if not os.path.exists('/home/vagrant/myconnectome/.started'):
-        my_env = os.environ.copy()
-        my_env['MYCONNECTOME_DIR'] = '/home/vagrant/myconnectome'
-        my_env['WORKBENCH_BIN_DIR'] = '/usr/bin'
-        my_env['R_LIBS_USER'] = '/home/vagrant/R_libs'
-        os.chdir('/home/vagrant/myconnectome')
-        p = Popen(['/home/vagrant/miniconda/bin/python', '/home/vagrant/myconnectome/myconnectome/scripts/run_everything.py'],
-                   stdout=open('/home/vagrant/myconnectome/myconnectome_job.log', 'w'),
-                   stderr=open('/home/vagrant/myconnectome/myconnectome_job.err', 'a'),
-                   preexec_fn=os.setpgrp,
-                   env = my_env)
-        filey = open('/home/vagrant/myconnectome/.started','wb').close()
-
-    return redirect('/')
-
 @app.route('/')
 def show_analyses():
 
-    timeseries_files = {'/var/www/results/timeseries/timeseries_analyses.html':'Timeseries analyses',
-                       '/var/www/results/timeseries/Make_Timeseries_Heatmaps.html':'Timeseries heatmaps',
-                       '/var/www/results/timeseries/Make_timeseries_plots.html':'Timeseries plots',
-                       '/var/www/results/timeseries/behav_heatmap.pdf':'Behavioral timeseries heatmap',
-                       '/var/www/results/timeseries/wincorr_heatmap.pdf':'Within-network connectivity timeseries heatmap',
-                       '/var/www/results/timeseries/wincorr_heatmap.pdf':'Within-network connectivity timeseries heatmap',
-                       '/var/www/results/timeseries/wgcna_heatmap.pdf':'Gene expression module timeseries heatmap',
-                       '/var/www/results/timeseries':'Listing of all files'}
+    timeseries_files = {'/var/www/results/myconnectome/timeseries/timeseries_analyses.html':'Timeseries analyses',
+                       '/var/www/results/myconnectome/timeseries/Make_Timeseries_Heatmaps.html':'Timeseries heatmaps',
+                       '/var/www/results/myconnectome/timeseries/Make_timeseries_plots.html':'Timeseries plots',
+                       '/var/www/results/myconnectome/timeseries/behav_heatmap.pdf':'Behavioral timeseries heatmap',
+                       '/var/www/results/myconnectome/timeseries/wincorr_heatmap.pdf':'Within-network connectivity timeseries heatmap',
+                       '/var/www/results/myconnectome/timeseries/wincorr_heatmap.pdf':'Within-network connectivity timeseries heatmap',
+                       '/var/www/results/myconnectome/timeseries/wgcna_heatmap.pdf':'Gene expression module timeseries heatmap',
+                       '/var/www/results/myconnectome/timeseries':'Listing of all files'}
 
-    rna_files =        {'/var/www/results/rna-seq/RNAseq_data_preparation.html':'RNA-seq data preparation',
-                       '/var/www/results/rna-seq/Run_WGCNA.html':'RNA-seq WGCNA analysis',
-                       '/var/www/results/rna-seq/snyderome/Snyderome_data_preparation.html':'RNA-seq Snyderome analysis',
-                       '/var/www/results/rna-seq':'Listing of all files'}
+    rna_files =        {'/var/www/results/myconnectome/rna-seq/RNAseq_data_preparation.html':'RNA-seq data preparation',
+                       '/var/www/results/myconnectome/rna-seq/Run_WGCNA.html':'RNA-seq WGCNA analysis',
+                       '/var/www/results/myconnectome/rna-seq/snyderome/Snyderome_data_preparation.html':'RNA-seq Snyderome analysis',
+                       '/var/www/results/myconnectome/rna-seq':'Listing of all files'}
 
-    meta_files =       {'/var/www/results/metabolomics/Metabolomics_clustering.html':'Metabolomics data preparation',
-                        '/var/www/results/metabolomics':'Listing of all files'}
+    meta_files =       {'/var/www/results/myconnectome/metabolomics/Metabolomics_clustering.html':'Metabolomics data preparation',
+                        '/var/www/results/myconnectome/metabolomics':'Listing of all files'}
 
     # How many green links should we have?
     number_analyses = len(meta_files) + len(rna_files) + len(timeseries_files)
-
-    # If analyses not started, show button
-    start_button = True
-    if os.path.exists('/home/vagrant/myconnectome/.started'):
-        start_button = False
 
     # Check if the file exists, render context based on existence            
     counter = 0
@@ -151,7 +127,6 @@ def show_analyses():
     return render_template('index.html',timeseries_context=timeseries_context,
                                         rna_context=rna_context,
                                         meta_context=meta_context,
-                                        start_button=start_button,
                                         analysis_status=analysis_status)
 
 def create_context(link_dict,counter):
@@ -208,12 +183,8 @@ if ! [ -f /var/www/templates/index.html ]; then
 <div id='wrapper'>
   <div class='container'>
     <div class='logo_box'><h1>MyConnectome<br/>Analyses</h1>
-    <!-- Analysis Start Button-->
-    {% if start_button %}
-        <a class='btn btn-default' href='/start' style='left: 40px;bottom: 140px; position:absolute' role='button'>Start Analysis</a>
-    {% else %}
-        <a class='btn btn-default' href='#' style='left: 40px;bottom: 140px; position:absolute'; role='button' disabled>{{ analysis_status }}</a>
-    {% endif %}
+    <!-- Analysis Status Button-->
+    <a class='btn btn-default' href='#' style='left: 40px;bottom: 140px; position:absolute'; role='button' disabled>{{ analysis_status }}</a>
 
     </div>          
       <div class='main_box'>

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,11 +91,14 @@ def autoindex(path='.'):
 def start_analyses():
 
     if not os.path.exists('/home/vagrant/myconnectome/.started'):
+        my_env = os.environ.copy()
+        my_env['MYCONNECTOME_DIR'] = '/home/vagrant/myconnectome'
+        my_env['WORKBENCH_BIN_DIR'] = '/usr/bin'
         p = Popen(['/home/vagrant/miniconda/bin/python', '/home/vagrant/myconnectome/myconnectome/scripts/run_everything.py'],
                    stdout=open('/home/vagrant/myconnectome/myconnectome_job.log', 'w'),
                    stderr=open('/home/vagrant/myconnectome/myconnectome_job.err', 'a'),
                    preexec_fn=os.setpgrp,
-                   env = os.environ.copy())
+                   env = my_env)
         filey = open('/home/vagrant/myconnectome/.started','wb').close()
 
     return redirect('/')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,7 +94,8 @@ def start_analyses():
         p = Popen(['/home/vagrant/miniconda/bin/python', '/home/vagrant/myconnectome/myconnectome/scripts/run_everything.py']
                    stdout=open('/home/vagrant/myconnectome/myconnectome_job.log', 'w'),
                    stderr=open('/home/vagrant/myconnectome/myconnectome_job.err', 'a'),
-                   preexec_fn=os.setpgrp)
+                   preexec_fn=os.setpgrp,
+                   env = os.environ.copy())
         filey = open('/home/vagrant/myconnectome/.started','wb').close()
 
     return redirect('/')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,6 +94,7 @@ def start_analyses():
         my_env = os.environ.copy()
         my_env['MYCONNECTOME_DIR'] = '/home/vagrant/myconnectome'
         my_env['WORKBENCH_BIN_DIR'] = '/usr/bin'
+        os.chdir('/home/vagrant/myconnectome')
         p = Popen(['/home/vagrant/miniconda/bin/python', '/home/vagrant/myconnectome/myconnectome/scripts/run_everything.py'],
                    stdout=open('/home/vagrant/myconnectome/myconnectome_job.log', 'w'),
                    stderr=open('/home/vagrant/myconnectome/myconnectome_job.err', 'a'),

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ then
  chmod +x miniconda.sh
  ./miniconda.sh -b
  echo "export PATH=$HOME/miniconda/bin:\\$PATH" >> .bashrc
+ echo "export PATH=$HOME/miniconda/bin:\\$PATH" >> .env
 fi
 
 # install nipype dependencies
@@ -49,6 +50,7 @@ mkdir $HOME/R_libs
 sudo mkdir /var/www
 sudo mkdir /var/www/results
 echo "export R_LIBS_USER=$HOME/R_libs" >> .bashrc
+echo "export R_LIBS_USER=$HOME/R_libs" >> .env
 fi
 
 
@@ -57,6 +59,8 @@ then
   git clone https://github.com/poldrack/myconnectome.git $HOME/myconnectome
   echo "export MYCONNECTOME_DIR=$HOME/myconnectome" >> .bashrc
   echo "export WORKBENCH_BIN_DIR=/usr/bin" >> .bashrc
+  echo "export MYCONNECTOME_DIR=$HOME/myconnectome" >> .env
+  echo "export WORKBENCH_BIN_DIR=/usr/bin" >> .env
   cd $HOME/myconnectome
 fi
 
@@ -267,9 +271,11 @@ user = vagrant
   sudo cp /tmp/abcde /etc/supervisor/conf.d/flask_project.conf
 fi
 
+# Install my connectome and start analyses
 cd /home/vagrant/myconnectome
 $HOME/miniconda/bin/python /home/vagrant/myconnectome/setup.py install
 
+# Start the flask application via supervisor
 sudo ln -s /etc/nginx/sites-available/flask_project /etc/nginx/sites-enabled/flask_project
 cd /var/www
 sudo /etc/init.d/nginx restart
@@ -277,6 +283,12 @@ sudo supervisorctl reread
 sudo supervisorctl update
 sudo supervisorctl start flask_project
 echo "Open browser to 192.168.0.20:5000"
+
+# Start the analysis for the user
+touch /home/vagrant/myconnectome/.started
+source /home/vagrant/.env
+$HOME/miniconda/bin/python /home/vagrant/myconnectome/myconnectome/scripts/run_everything.py > /home/vagrant/myconnectome/myconnectome_job.out 2> /home/vagrant/myconnectome/myconnectome_job.err &
+
 
 SCRIPT
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,10 @@ def autoindex(path='.'):
 def start_analyses():
 
     if not os.path.exists('/home/vagrant/myconnectome/.started'):
-        p = Popen(['python', '/home/vagrant/myconnectome/myconnectome/scripts/run_everything.py'])
+        p = Popen(['/home/vagrant/miniconda/bin/python', '/home/vagrant/myconnectome/myconnectome/scripts/run_everything.py']
+                   stdout=open('/home/vagrant/myconnectome/myconnectome_job.log', 'w'),
+                   stderr=open('/home/vagrant/myconnectome/myconnectome_job.err', 'a'),
+                   preexec_fn=os.setpgrp)
         filey = open('/home/vagrant/myconnectome/.started','wb').close()
 
     return redirect('/')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,6 +94,7 @@ def start_analyses():
         my_env = os.environ.copy()
         my_env['MYCONNECTOME_DIR'] = '/home/vagrant/myconnectome'
         my_env['WORKBENCH_BIN_DIR'] = '/usr/bin'
+        my_env['R_LIBS_USER'] = '/home/vagrant/R_libs'
         os.chdir('/home/vagrant/myconnectome')
         p = Popen(['/home/vagrant/miniconda/bin/python', '/home/vagrant/myconnectome/myconnectome/scripts/run_everything.py'],
                    stdout=open('/home/vagrant/myconnectome/myconnectome_job.log', 'w'),

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,8 @@ sudo apt-get install -y --force-yes supervisor
 if [ ! -d $HOME/R_libs ]
 then
 mkdir $HOME/R_libs
-mkdir /var/www/results
+sudo mkdir /var/www
+sudo mkdir /var/www/results
 echo "export R_LIBS_USER=$HOME/R_libs" >> .bashrc
 fi
 
@@ -86,7 +87,7 @@ def autoindex(path='.'):
     return index.render_autoindex(path)
 
 
-@app.route('/start'):
+@app.route('/start')
 def start_analyses():
 
     if not os.path.exists('/home/vagrant/myconnectome/.started'):
@@ -130,9 +131,9 @@ def show_analyses():
     meta_context,counter = create_context(meta_files,counter)
 
     # The counter determines if we've finished running analyses
-    analysis_status = "Analyses Are Running"
+    analysis_status = 'Analyses Are Running'
     if counter == number_analyses:
-        analysis_status = "Analysis Complete"
+        analysis_status = 'Analysis Complete'
 
     return render_template('index.html',timeseries_context=timeseries_context,
                                         rna_context=rna_context,
@@ -181,7 +182,7 @@ if ! [ -f /var/www/templates/index.html ]; then
     <link href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css' rel='stylesheet'>
 
     <style>
-    @import "http://fonts.googleapis.com/css?family=Lato:400,300,700,900";body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0}table{border-collapse:collapse;border-spacing:0}fieldset,img{border:0}address,caption,dfn,th,var{font-style:normal;font-weight:400}li{list-style:none}caption,th{text-align:left}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:400}body{background:url(https://raw.githubusercontent.com/vsoch/myconnectome-vm/update/flask/assets/img/bg.jpg);font-family:'Lato',sans-serif;font-weight:300;font-size:16px;color:#555;line-height:1.6em;-webkit-font-smoothing:antialiased;-webkit-overflow-scrolling:touch}h1,h2,h3,h4,h5,h6{font-family:'Lato',sans-serif;font-weight:300;color:#444}h1{font-size:40px}p{margin-bottom:20px;font-size:16px}a{color:#ACBAC1;word-wrap:break-word;-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}a:hover,a:focus{color:#4F92AF;text-decoration:none;outline:0}a:before,a:after{-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}.alignleft{text-align:left}.alignright{text-align:right}.aligncenter{text-align:center}.btn{display:inline-block;padding:10px 20px;margin-bottom:0;font-size:14px;font-weight:400;line-height:1.428571429;text-align:center;white-space:nowrap;vertical-align:middle;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;background-image:none;border:1px solid transparent;border-radius:0}#wrapper{text-align:center;padding:50px 0;min-height:650px;width:100%;-webkit-background-size:100%;-moz-background-size:100%;-o-background-size:100%;background-size:100%;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover}#wrapper h1{margin-top:60px;margin-bottom:40px;color:#fff;font-size:45px;font-weight:900;letter-spacing:-1px}h2.subtitle{color:#fff;font-size:24px}.logo_box{width:349px;float:left;border-right:1px solid #303030;height:600px;position:relative}h1{padding:12px 70px 12px 20px;position:absolute;right:0;text-align:left;top:25%;float:left;color:#fff;letter-spacing:-1px;font-size:38px}h1 cufon{margin-bottom:-4px}.main_box{float:left;width:500px;height:600px;padding:25px}h2{font-family:Georgia;color:#ffe400;font-size:24px;margin-bottom:10px;margin-top:20px}h2 span{color:#fff;font-size:16px;line-height:26px;font-style:italic}ul.info{width:500px;padding:0;margin:10px 0 0;float:left}ul.info li{margin-bottom:20px;clear:both;float:left}ul.info li p{font-size:13px;line-height:20px;color:#fff;float:left;margin:0}.connect{width:145px;padding-left:20px;float:left;padding-top:20px}.connect img{margin-right:5px} analysisbutton {left: 40px;bottom: 140px; position:absolute}
+    @import "http://fonts.googleapis.com/css?family=Lato:400,300,700,900";body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0}table{border-collapse:collapse;border-spacing:0}fieldset,img{border:0}address,caption,dfn,th,var{font-style:normal;font-weight:400}li{list-style:none}caption,th{text-align:left}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:400}body{background:url(https://raw.githubusercontent.com/vsoch/myconnectome-vm/update/flask/assets/img/bg.jpg);font-family:'Lato',sans-serif;font-weight:300;font-size:16px;color:#555;line-height:1.6em;-webkit-font-smoothing:antialiased;-webkit-overflow-scrolling:touch}h1,h2,h3,h4,h5,h6{font-family:'Lato',sans-serif;font-weight:300;color:#444}h1{font-size:40px}p{margin-bottom:20px;font-size:16px}a{color:#ACBAC1;word-wrap:break-word;-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}a:hover,a:focus{color:#4F92AF;text-decoration:none;outline:0}a:before,a:after{-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}.alignleft{text-align:left}.alignright{text-align:right}.aligncenter{text-align:center}.btn{display:inline-block;padding:10px 20px;margin-bottom:0;font-size:14px;font-weight:400;line-height:1.428571429;text-align:center;white-space:nowrap;vertical-align:middle;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;background-image:none;border:1px solid transparent;border-radius:0}#wrapper{text-align:center;padding:50px 0;min-height:650px;width:100%;-webkit-background-size:100%;-moz-background-size:100%;-o-background-size:100%;background-size:100%;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover}#wrapper h1{margin-top:60px;margin-bottom:40px;color:#fff;font-size:45px;font-weight:900;letter-spacing:-1px}h2.subtitle{color:#fff;font-size:24px}.logo_box{width:349px;float:left;border-right:1px solid #303030;height:600px;position:relative}h1{padding:12px 70px 12px 20px;position:absolute;right:0;text-align:left;top:25%;float:left;color:#fff;letter-spacing:-1px;font-size:38px}h1 cufon{margin-bottom:-4px}.main_box{float:left;width:500px;height:600px;padding:25px}h2{font-family:Georgia;color:#ffe400;font-size:24px;margin-bottom:10px;margin-top:20px}h2 span{color:#fff;font-size:16px;line-height:26px;font-style:italic}ul.info{width:500px;padding:0;margin:10px 0 0;float:left}ul.info li{margin-bottom:20px;clear:both;float:left}ul.info li p{font-size:13px;line-height:20px;color:#fff;float:left;margin:0}.connect{width:145px;padding-left:20px;float:left;padding-top:20px}.connect img{margin-right:5px}
     </style>
     
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -196,9 +197,9 @@ if ! [ -f /var/www/templates/index.html ]; then
     <div class='logo_box'><h1>MyConnectome<br/>Analyses</h1>
     <!-- Analysis Start Button-->
     {% if start_button %}
-        <a class="btn btn-default" href="/start" role="button">Start Analyses</a>
+        <a class='btn btn-default' href='/start' style='left: 40px;bottom: 140px; position:absolute' role='button'>Start Analyses</a>
     {% else %}
-        <a class="btn btn-default" href="#" role="button" disabled>{{ analysis_status }}</a>
+        <a class='btn btn-default' href='#' style='left: 40px;bottom: 140px; position:absolute'; role='button' disabled>{{ analysis_status }}</a>
     {% endif %}
 
     </div>          
@@ -266,6 +267,7 @@ sudo /etc/init.d/nginx restart
 sudo supervisorctl reread
 sudo supervisorctl update
 sudo supervisorctl start flask_project
+echo "Open browser to 192.168.0.20:5000"
 
 SCRIPT
 


### PR DESCRIPTION
I was able to do this sooner rather than later because it looks like the raw HCP data is still in the process of being copied.
- Add a "Run Analysis" button to the main interface. This button is active only before analyses are started, and this status is determined by the existence of a ".started" file in /home/vagrant/myconnectome. The button works by calling an application url "start" that only serves to execute the run_everything.py, and then write the ".started" file and redirect to the main page.  When this has been done, the "Run Analysis" button changes to a disabled "Analysis is Running." button.
- The page checks for the count of analyses that are finished (based on existence of the result files), and when the count of finished == count of total possible, the button changes to "Analysis is Complete."
- The base page is now the main MyConnectome analysis page. This was much harder than I anticipated - there was no way I could figure out to generate directory listings for a custom set of folders (many errors were propogated for the different versions of this that I tried) and changing the app.route to '/' did not work, as the plugin seems to always want the root to be a listing. What worked was creating a symbolic link between the myconnectome folder and a "results" folder in /var/www, and then telling the plugin that the root was the results folder.

I've tested that it works to start and run the analyses, and I also tested locally that the button changes when analyses finish, although I have not tested this last part from a fresh install (for example, what if there are issues with writing to stdout when being run in this fashion?). It is running now and I will edit this PR if any other issues come up!
