### PR TITLE
Check for error, and display logs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -105,7 +105,7 @@ def show_log():
 
 def read_log(logfile):
     logg = open(logfile,'rb').readlines()
-    logg = [l.strip('\n') for l in logg]
+    logg = [l[0:-1] for l in logg]
     logg = Markup('<br>'.join(logg))
     return logg
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -159,7 +159,7 @@ def show_analyses():
 
 # Check if python process is still running
 def check_process():
-    process_id = int(os.environ['MYCONNECTOME_ID'])
+    process_id = int(open('/home/vagrant/myconnectome/.started','rb').readlines()[0][0:-1])
     try:
         os.kill(process_id, 0)
     except OSError: 
@@ -382,7 +382,7 @@ if ! [ -f $HOME/myconnectome/.started ]; then
   $HOME/miniconda/bin/python /home/vagrant/myconnectome/myconnectome/scripts/run_everything.py > /home/vagrant/myconnectome/myconnectome_job.out 2> /home/vagrant/myconnectome/myconnectome_job.err &
   # Get the process ID
   MYCONNECTOME_ID=`pgrep python`
-  export MYCONNECTOME_ID
+  sudo echo "$MYCONNECTOME_ID" >> /home/vagrant/myconnectome/.started
 fi
   
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,7 +81,6 @@ from flask import Flask, render_template, redirect
 from flask.ext.autoindex import AutoIndex
 from subprocess import Popen
 import os
-from collections import OrderedDict
 
 app = Flask(__name__)
 index = AutoIndex(app, browse_root='/var/www/results',add_url_rules=False)
@@ -173,8 +172,8 @@ if ! [ -f /var/www/templates/index.html ]; then
     <link href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css' rel='stylesheet'>
 
     <style>
-    @import "http://fonts.googleapis.com/css?family=Lato:400,300,700,900";body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0}table{border-collapse:collapse;border-spacing:0}fieldset,img{border:0}address,caption,dfn,th,var{font-style:normal;font-weight:400}li{list-style:none}caption,th{text-align:left}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:400}body{background:url(https://raw.githubusercontent.com/vsoch/myconnectome-vm/update/flask/assets/img/bg.jpg);font-family:'Lato',sans-serif;font-weight:300;font-size:16px;color:#555;line-height:1.6em;-webkit-font-smoothing:antialiased;-webkit-overflow-scrolling:touch}h1,h2,h3,h4,h5,h6{font-family:'Lato',sans-serif;font-weight:300;color:#444}h1{font-size:40px}p{margin-bottom:20px;font-size:16px}a{color:#ACBAC1;word-wrap:break-word;-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}a:hover,a:focus{color:#4F92AF;text-decoration:none;outline:0}a:before,a:after{-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}.alignleft{text-align:left}.alignright{text-align:right}.aligncenter{text-align:center}.btn{display:inline-block;padding:10px 20px;margin-bottom:0;font-size:14px;font-weight:400;line-height:1.428571429;text-align:center;white-space:nowrap;vertical-align:middle;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;background-image:none;border:1px solid transparent;border-radius:0}#wrapper{text-align:center;padding:50px 0;min-height:650px;width:100%;-webkit-background-size:100%;-moz-background-size:100%;-o-background-size:100%;background-size:100%;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover}#wrapper h1{margin-top:60px;margin-bottom:40px;color:#fff;font-size:45px;font-weight:900;letter-spacing:-1px}h2.subtitle{color:#fff;font-size:24px}.logo_box{width:349px;float:left;border-right:1px solid #303030;height:600px;position:relative}h1{padding:12px 70px 12px 20px;position:absolute;right:0;text-align:left;top:25%;float:left;color:#fff;letter-spacing:-1px;font-size:38px}h1 cufon{margin-bottom:-4px}.main_box{float:left;width:500px;height:600px;padding:25px}h2{font-family:Georgia;color:#ffe400;font-size:24px;margin-bottom:10px;margin-top:20px}h2 span{color:#fff;font-size:16px;line-height:26px;font-style:italic}ul.info{width:500px;padding:0;margin:10px 0 0;float:left}ul.info li{margin-bottom:20px;clear:both;float:left}ul.info li p{font-size:13px;line-height:20px;color:#fff;float:left;margin:0}.connect{width:145px;padding-left:20px;float:left;padding-top:20px}.connect img{margin-right:5px}
-    </style>
+    @import "http://fonts.googleapis.com/css?family=Lato:400,300,700,900";body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0}table{border-collapse:collapse;border-spacing:0}fieldset,img{border:0}address,caption,dfn,th,var{font-style:normal;font-weight:400}li{list-style:none}caption,th{text-align:left}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:400}body{background:url(https://raw.githubusercontent.com/vsoch/myconnectome-vm/update/flask/assets/img/bg.jpg);font-family:'Lato',sans-serif;font-weight:300;font-size:16px;color:#555;line-height:1.6em;-webkit-font-smoothing:antialiased;-webkit-overflow-scrolling:touch}h1,h2,h3,h4,h5,h6{font-family:'Lato',sans-serif;font-weight:300;color:#444}h1{font-size:40px}p{margin-bottom:20px;font-size:16px}a{color:#ACBAC1;word-wrap:break-word;-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}a:hover,a:focus{color:#4F92AF;text-decoration:none;outline:0}a:before,a:after{-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}.alignleft{text-align:left}.alignright{text-align:right}.aligncenter{text-align:center}.btn{display:inline-block;padding:10px 20px;margin-bottom:0;font-size:14px;font-weight:400;line-height:1.428571429;text-align:center;white-space:nowrap;vertical-align:middle;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;background-image:none;border:1px solid transparent;border-radius:0}#wrapper{text-align:center;padding:50px 0;min-height:650px;width:100%;-webkit-background-size:100%;-moz-background-size:100%;-o-background-size:100%;background-size:100%;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover}#wrapper h1{margin-top:60px;margin-bottom:40px;color:#fff;font-size:45px;font-weight:900;letter-spacing:-1px}h2.subtitle{color:#fff;font-size:24px}.logo_box{width:349px;float:left;border-right:1px solid #303030;height:600px;position:relative}h1{padding:12px 70px 12px 20px;position:absolute;right:0;text-align:left;top:25%;float:left;color:#fff;letter-spacing:-1px;font-size:38px}h1 cufon{margin-bottom:-4px}.main_box{float:left;width:500px;height:600px;padding:25px}h2{font-family:Georgia;color:#ffe400;font-size:24px;margin-bottom:10px;margin-top:20px}h2 span{color:#fff;font-size:16px;line-height:26px;font-style:italic}ul.info{width:500px;padding:0;margin:10px 0 0;float:left}ul.info li{margin-bottom:20px;clear:both;float:left}ul.info li p{font-size:13px;line-height:20px;color:#fff;float:left;margin:0}.connect{width:145px;padding-left:20px;float:left;padding-top:20px}.connect img{margin-right:5px}.links{bottom: 0px;position: absolute; left: -50px;}
+</style>
     
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -185,12 +184,20 @@ if ! [ -f /var/www/templates/index.html ]; then
   <body>
 <div id='wrapper'>
   <div class='container'>
+    <!-- Left Box-->
     <div class='logo_box'><h1>MyConnectome<br/>Analyses</h1>
-    <!-- Analysis Status Button-->
-    <a class='btn btn-default' href='#' style='left: 40px;bottom: 140px; position:absolute'; role='button' disabled>{{ analysis_status }}</a>
-
-    </div>          
-      <div class='main_box'>
+       <div class="links">
+        <!-- Analysis Status Button-->
+        <a class='btn btn-default' href='#' role='button' style="margin-bottom:40px" disabled>{{ analysis_status }}</a>    
+            <ul>
+               <li><a href="https://github.com/poldrack/myconnectome-vm" target="_blank">Learn more about the MyConnectome Virtual Machine</a></li>
+               <li><a href="http://myconnectome.org" target="_blank">Learn more about the MyConnectome Project</a></li>
+             </ul>
+       </div>
+    </div><!-- End Left Box-->
+    
+    <!-- Right Box-->         
+    <div class='main_box'>
 	<h2>Timeseries analyses</h2>
 	<ul>
             {% for timeseries_url, timeseries_description, timeseries_style, timeseries_title in timeseries_context %}
@@ -208,11 +215,8 @@ if ! [ -f /var/www/templates/index.html ]; then
             {% for meta_url, meta_description, meta_style, meta_title in meta_context %}
     	    <li><a href='{{ meta_url }}' style='{{ meta_style }}' title='{{ meta_title }}'>{{ meta_description }}</a></li>
             {% endfor %}		
-	</ul>
-  <h2><a href="https://github.com/poldrack/myconnectome-vm">Learn more about the MyConnectome Virtual Machine</a></h2>
-  <h2><a href="http://myconnectome.org">Learn more about the MyConnectome Project</a></h2>
-  
-    </div>
+	</ul>  
+    </div><!-- End Right Box-->         
   </div>
 </div>
     <script src='https://code.jquery.com/jquery-2.1.4.min.js'></script>

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -315,8 +315,8 @@ if ! [ -f /var/www/templates/log.html ]; then
 <div class='wrapper' style='padding-left:20px;padding-top:20px;padding-right:20px'>
     <!-- Nav tabs -->
     <ul class='nav nav-tabs' role='tablist'>
-        <li class='active'><a href='#error' role='tab' data-toggle='tab' style='color:red'>Error Log</a></li>
-        <li><a href='#output' role='tab' data-toggle='tab' style='color:red'>Output Log</a></li>
+        <li class='active'><a href='#error' role='tab' data-toggle='tab' style='color:#ACBAC1'>Error Log</a></li>
+        <li><a href='#output' role='tab' data-toggle='tab' style='color:#ACBAC1'>Output Log</a></li>
     </ul>
     <!-- Tab panes -->
     <div class='tab-content'>

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,16 +68,22 @@ if ! [ -L /var/www/myconnectome ]; then
   sudo ln -fs /home/vagrant/myconnectome /var/www/results
 fi
 
-# Web interface
+# Web templates directory
 if [ ! -d /var/www/templates ]
 then
   sudo mkdir /var/www/templates
 fi
 
+# Static files folder
+if [ ! -d /var/www/static ]
+then
+  sudo mkdir /var/www/static
+fi
+
 # Index script
 if ! [ -f /var/www/index.py ]; then
   echo """
-from flask import Flask, render_template, redirect
+from flask import Flask, render_template, redirect, Markup
 from flask.ext.autoindex import AutoIndex
 from subprocess import Popen
 import os
@@ -89,6 +95,20 @@ index = AutoIndex(app, browse_root='/var/www/results',add_url_rules=False)
 @app.route('/results/<path:path>')
 def autoindex(path='.'):
     return index.render_autoindex(path)
+
+@app.route('/log')
+def show_log():
+    err_log = read_log('/var/www/results/myconnectome/myconnectome_job.err')
+    out_log = read_log('/var/www/results/myconnectome/myconnectome_job.out')
+    return render_template('log.html',err_log=err_log,
+                                      out_log=out_log)
+
+def read_log(logfile):
+    logg = open(logfile,'rb').readlines()
+    logg = [l.strip('\n') for l in logg]
+    logg = Markup('<br>'.join(logg))
+    return logg
+
 
 @app.route('/')
 def show_analyses():
@@ -121,13 +141,31 @@ def show_analyses():
 
     # The counter determines if we've finished running analyses
     analysis_status = 'Analysis is Running'
-    if counter == number_analyses:
-        analysis_status = 'Analysis Complete'
+    
+    # Check if the process is still running
+    process_running = check_process()
+
+    # If the process is not running
+    if process_running == False:
+        if counter == number_analyses:
+            analysis_status = 'Analysis Complete'
+        else:
+            analysis_status = 'Check for Error'
 
     return render_template('index.html',timeseries_context=timeseries_context,
                                         rna_context=rna_context,
                                         meta_context=meta_context,
                                         analysis_status=analysis_status)
+
+# Check if python process is still running
+def check_process():
+    process_id = int(os.environ['MYCONNECTOME_ID'])
+    try:
+        os.kill(process_id, 0)
+    except OSError: 
+        return False
+    else: 
+        return True
 
 def create_context(links,counter):
     urls = []; descriptions = []; styles = []; titles = []
@@ -154,6 +192,15 @@ if __name__ == '__main__':
   sudo cp /tmp/boocoo /var/www/index.py
 fi
 
+# Style Sheet
+# Index script
+if ! [ -f /var/www/static/style.css ]; then
+  echo """
+@import 'http://fonts.googleapis.com/css?family=Lato:400,300,700,900';body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0}table{border-collapse:collapse;border-spacing:0}fieldset,img{border:0}address,caption,dfn,th,var{font-style:normal;font-weight:400}li{list-style:none}caption,th{text-align:left}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:400}body{background:url(https://raw.githubusercontent.com/vsoch/myconnectome-vm/update/flask/assets/img/bg.jpg);font-family:'Lato',sans-serif;font-weight:300;font-size:16px;color:#555;line-height:1.6em;-webkit-font-smoothing:antialiased;-webkit-overflow-scrolling:touch}h1,h2,h3,h4,h5,h6{font-family:'Lato',sans-serif;font-weight:300;color:#444}h1{font-size:40px}p{margin-bottom:20px;font-size:16px}a{color:#ACBAC1;word-wrap:break-word;-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}a:hover,a:focus{color:#4F92AF;text-decoration:none;outline:0}a:before,a:after{-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}.alignleft{text-align:left}.alignright{text-align:right}.aligncenter{text-align:center}.btn{display:inline-block;padding:10px 20px;margin-bottom:0;font-size:14px;font-weight:400;line-height:1.428571429;text-align:center;white-space:nowrap;vertical-align:middle;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;background-image:none;border:1px solid transparent;border-radius:0}#wrapper{text-align:center;padding:50px 0;min-height:650px;width:100%;-webkit-background-size:100%;-moz-background-size:100%;-o-background-size:100%;background-size:100%;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover}#wrapper h1{margin-top:60px;margin-bottom:40px;color:#fff;font-size:45px;font-weight:900;letter-spacing:-1px}h2.subtitle{color:#fff;font-size:24px}.logo_box{width:349px;float:left;border-right:1px solid #303030;height:600px;position:relative}h1{padding:12px 70px 12px 20px;position:absolute;right:0;text-align:left;top:25%;float:left;color:#fff;letter-spacing:-1px;font-size:38px}h1 cufon{margin-bottom:-4px}.main_box{float:left;width:500px;height:600px;padding:25px}h2{font-family:Georgia;color:#ffe400;font-size:24px;margin-bottom:10px;margin-top:20px}h2 span{color:#fff;font-size:16px;line-height:26px;font-style:italic}ul.info{width:500px;padding:0;margin:10px 0 0;float:left}ul.info li{margin-bottom:20px;clear:both;float:left}ul.info li p{font-size:13px;line-height:20px;color:#fff;float:left;margin:0}.connect{width:145px;padding-left:20px;float:left;padding-top:20px}.connect img{margin-right:5px}.links{bottom: 0px;position: absolute; left: -50px;}
+""" >/tmp/purpsee
+  sudo cp /tmp/purpsee /var/www/static/style.css
+fi
+
 # Index Template
 if ! [ -f /var/www/templates/index.html ]; then
   echo """
@@ -166,14 +213,13 @@ if ! [ -f /var/www/templates/index.html ]; then
     <meta name='description' content='MyConnectome Analyses, Poldracklab'>
     <meta name='author' content='Poldracklab'>
 
-    <title>My Connectome Analyses</title>
+    <title>MyConnectome Analyses</title>
 
     <!-- Bootstrap -->
     <link href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css' rel='stylesheet'>
 
-    <style>
-    @import "http://fonts.googleapis.com/css?family=Lato:400,300,700,900";body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0}table{border-collapse:collapse;border-spacing:0}fieldset,img{border:0}address,caption,dfn,th,var{font-style:normal;font-weight:400}li{list-style:none}caption,th{text-align:left}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:400}body{background:url(https://raw.githubusercontent.com/vsoch/myconnectome-vm/update/flask/assets/img/bg.jpg);font-family:'Lato',sans-serif;font-weight:300;font-size:16px;color:#555;line-height:1.6em;-webkit-font-smoothing:antialiased;-webkit-overflow-scrolling:touch}h1,h2,h3,h4,h5,h6{font-family:'Lato',sans-serif;font-weight:300;color:#444}h1{font-size:40px}p{margin-bottom:20px;font-size:16px}a{color:#ACBAC1;word-wrap:break-word;-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}a:hover,a:focus{color:#4F92AF;text-decoration:none;outline:0}a:before,a:after{-webkit-transition:color .1s ease-in,background .1s ease-in;-moz-transition:color .1s ease-in,background .1s ease-in;-ms-transition:color .1s ease-in,background .1s ease-in;-o-transition:color .1s ease-in,background .1s ease-in;transition:color .1s ease-in,background .1s ease-in}.alignleft{text-align:left}.alignright{text-align:right}.aligncenter{text-align:center}.btn{display:inline-block;padding:10px 20px;margin-bottom:0;font-size:14px;font-weight:400;line-height:1.428571429;text-align:center;white-space:nowrap;vertical-align:middle;cursor:pointer;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none;background-image:none;border:1px solid transparent;border-radius:0}#wrapper{text-align:center;padding:50px 0;min-height:650px;width:100%;-webkit-background-size:100%;-moz-background-size:100%;-o-background-size:100%;background-size:100%;-webkit-background-size:cover;-moz-background-size:cover;-o-background-size:cover;background-size:cover}#wrapper h1{margin-top:60px;margin-bottom:40px;color:#fff;font-size:45px;font-weight:900;letter-spacing:-1px}h2.subtitle{color:#fff;font-size:24px}.logo_box{width:349px;float:left;border-right:1px solid #303030;height:600px;position:relative}h1{padding:12px 70px 12px 20px;position:absolute;right:0;text-align:left;top:25%;float:left;color:#fff;letter-spacing:-1px;font-size:38px}h1 cufon{margin-bottom:-4px}.main_box{float:left;width:500px;height:600px;padding:25px}h2{font-family:Georgia;color:#ffe400;font-size:24px;margin-bottom:10px;margin-top:20px}h2 span{color:#fff;font-size:16px;line-height:26px;font-style:italic}ul.info{width:500px;padding:0;margin:10px 0 0;float:left}ul.info li{margin-bottom:20px;clear:both;float:left}ul.info li p{font-size:13px;line-height:20px;color:#fff;float:left;margin:0}.connect{width:145px;padding-left:20px;float:left;padding-top:20px}.connect img{margin-right:5px}.links{bottom: 0px;position: absolute; left: -50px;}
-</style>
+    <!--Style-->
+    <link rel=stylesheet type=text/css href='{{ url_for('static', filename='style.css') }}'>
     
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -186,12 +232,16 @@ if ! [ -f /var/www/templates/index.html ]; then
   <div class='container'>
     <!-- Left Box-->
     <div class='logo_box'><h1>MyConnectome<br/>Analyses</h1>
-       <div class="links">
+       <div class='links'>
         <!-- Analysis Status Button-->
-        <a class='btn btn-default' href='#' role='button' style="margin-bottom:40px" disabled>{{ analysis_status }}</a>    
+        {% if analysis_status == 'Check for Error' %}
+        <a class='btn btn-default' href='/error' role='button' style='margin-bottom:40px'>{{ analysis_status }}</a>    
+        {% else %}
+        <a class='btn btn-default' href='#' role='button' style='margin-bottom:40px' disabled>{{ analysis_status }}</a>    
+        {% endif %}
             <ul>
-               <li><a href="https://github.com/poldrack/myconnectome-vm" target="_blank">Learn more about the MyConnectome Virtual Machine</a></li>
-               <li><a href="http://myconnectome.org" target="_blank">Learn more about the MyConnectome Project</a></li>
+               <li><a href='https://github.com/poldrack/myconnectome-vm' target='_blank'>Learn more about the MyConnectome Virtual Machine</a></li>
+               <li><a href='http://myconnectome.org' target='_blank'>Learn more about the MyConnectome Project</a></li>
              </ul>
        </div>
     </div><!-- End Left Box-->
@@ -226,6 +276,63 @@ if ! [ -f /var/www/templates/index.html ]; then
 """ >/tmp/asfdlkjsd
   sudo cp /tmp/asfdlkjsd /var/www/templates/index.html 
 fi
+
+
+# Error and Output Log Template
+if ! [ -f /var/www/templates/log.html ]; then
+  echo """
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+    <meta name='description' content='MyConnectome Analyses, Poldracklab'>
+    <meta name='author' content='Poldracklab'>
+    <link rel='shortcut icon' href='assets/img/favicon.png'>
+
+    <title>MyConnectome Logs</title>
+
+    <!--Style-->
+    <link rel=stylesheet type=text/css href='{{ url_for('static', filename='style.css') }}'>
+
+    <!-- Bootstrap -->
+    <link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css'>
+    <!-- Optional theme -->
+    <link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css'>
+    <!-- Latest compiled and minified JavaScript -->
+    <script src='https://code.jquery.com/jquery-2.1.4.min.js'></script>
+    <script src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js'></script>
+
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src='https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js'></script>
+      <script src='https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js'></script>
+    <![endif]-->
+</head>
+
+<body>
+<div class='wrapper' style='padding-left:20px;padding-top:20px;padding-right:20px'>
+    <!-- Nav tabs -->
+    <ul class='nav nav-tabs' role='tablist'>
+        <li class='active'><a href='#error' role='tab' data-toggle='tab' style='color:red'>Error Log</a></li>
+        <li><a href='#output' role='tab' data-toggle='tab' style='color:red'>Output Log</a></li>
+    </ul>
+    <!-- Tab panes -->
+    <div class='tab-content'>
+        <div class='tab-pane active' id='error'>
+            <div class='well well-lg' style='margin-top:20px;overflow:scroll'>{{err_log}}</div>
+        </div>
+            <div class='tab-pane' id='output'>
+             <div class='well well-lg' style='margin-top:20px; overflow:scroll;'>{{out_log}}</div>
+        </div>
+    </div>
+  </body>
+</html>
+""" >/tmp/ooiilkj
+  sudo cp /tmp/ooiilkj /var/www/templates/log.html 
+fi
+
 
 sudo /etc/init.d/nginx start
 sudo rm /etc/nginx/sites-enabled/default
@@ -273,6 +380,9 @@ if ! [ -f $HOME/myconnectome/.started ]; then
   touch /home/vagrant/myconnectome/.started
   source /home/vagrant/.env
   $HOME/miniconda/bin/python /home/vagrant/myconnectome/myconnectome/scripts/run_everything.py > /home/vagrant/myconnectome/myconnectome_job.out 2> /home/vagrant/myconnectome/myconnectome_job.err &
+  # Get the process ID
+  MYCONNECTOME_ID=`pgrep python`
+  export MYCONNECTOME_ID
 fi
   
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -235,7 +235,7 @@ if ! [ -f /var/www/templates/index.html ]; then
        <div class='links'>
         <!-- Analysis Status Button-->
         {% if analysis_status == 'Check for Error' %}
-        <a class='btn btn-default' href='/error' role='button' style='margin-bottom:40px'>{{ analysis_status }}</a>    
+        <a class='btn btn-default' href='/log' role='button' style='margin-bottom:40px'>{{ analysis_status }}</a>    
         {% else %}
         <a class='btn btn-default' href='#' role='button' style='margin-bottom:40px' disabled>{{ analysis_status }}</a>    
         {% endif %}


### PR DESCRIPTION
This is the first of two PRs that will add the functionality discussed at our last meeting.  Specifically, this PR is about checking analysis status and directing the user to error logs.  We check that the analysis process is still running, check the status of the output files, and in the case that the analysis has stopped and output is missing, display a message (and link) to check logs.  

The updates are as follows:
- Move "more information" links to the left side,make text smaller, and open in a new window as not to lose the MyConnectome page.
- Addition of a "MyConnectome Logs" page that includes full text from both error and output logs. This log page is available at the url "/log,"

![log](https://cloud.githubusercontent.com/assets/814322/7928167/5ea6c7d0-08a0-11e5-9f3b-8bd86bde0a79.png)

I noticed for this page that R has a strange preference for what is considered "error" vs. "output." Output seems to be things that are printed to the screen, and "error" is messages and warnings that (also printed to the screen) but are more about installation of packages, etc. I think it's a better idea to break these outputs apart, as in the case of an error, the user will 100% find the error message at the bottom of the error log.  The other choice that we have is to put both messages into one text file, but I don't think this is preferable.
- Since we now have multiple pages using the same style, I've added a "static" folder, and moved the styles into "style.css"
- The Analysis Status button will display "Check for Error" (linked to the log) in the case that the analysis process (a python process) has stopped running, and the number of output files expected is not equal to the number of output files actual. 

![checkforerror](https://cloud.githubusercontent.com/assets/814322/7928203/cd49679c-08a0-11e5-8d2a-d6a745b1d06b.png)

This works by grabbing the process ID directly after it is submit (when the user does not yet have time to log in and we have certainty of 1 python process running) and saving it to the .started test file in the myconnectome folder.  The web interface then reads in the PID from this file, and checks to see if it is still running.
- If running: message says "Analysis is Running"
- if not running
  - if all output is there: message says "Analysis Complete
  - if output missing: message says "Check for Error" with link to log.

The one concern with the above approach is the fact that writing the PID to the log is not linked with running the run_everything.py script, but rather starting up the VM.  This would mean that if the user manually started the run_everything.py script, the PID would not be updated and the interface would incorrectly alert to check for errors.  I think we might want to add this task to be done within the run_everything.py file itself, including writing the .started file, grabbing the PID, and saving it. It would look something like this:

```
 import os
 filey = open("../../.started","rb") # two directories up in the same as "setup.py"
 process_id = os.getpid()
 filey.write(str(process_id))
 filey.close()
```

Then the only remaining issue is the chance that the user runs "run_everything.py" while a second python process is going in the virtual machine. This could lead to an error when we are assuming the file to have one process.  This is probably being too picky as its unlikely the user would choose heavily manual work over just restarting the VM, but I wanted to bring it up for discussion.
### Next PR

I am still working on the data exploration interface. I have a basic dropdown menu style, but I'm not convinced it's the best way to display / sort through such a large amount of information. I might have a few more questions that I will properly articulate in the next few days. I have not yet started looking into how to send a log to Amazon S3, I will tackle this after the data explorer.
