### PR TITLE
Removing supervisor controller to run application with gunicorn

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,8 +49,6 @@ sudo apt-get install -y --force-yes xserver-xorg-core
 
 # NGINX install
 sudo apt-get install -y --force-yes nginx
-sudo apt-get install -y --force-yes supervisor
-
 
 if [ ! -d $HOME/R_libs ]
 then
@@ -114,31 +112,15 @@ server {
   sudo cp /tmp/aijfaef /etc/nginx/sites-available/flask_project
 fi
 
-# Supervisor Configuration
-if ! [ -f /etc/supervisor/conf.d/flask_project.conf ]; then
-  echo """[program:flask_project]
-command = /home/vagrant/miniconda/bin/gunicorn index:app -b 0.0.0.0:5000
-directory = /var/www
-user = vagrant
-""" >/tmp/abcde
-  sudo cp /tmp/abcde /etc/supervisor/conf.d/flask_project.conf
-fi
-
 # Install my connectome and start analyses
 if ! [ -f $HOME/myconnectome/.started ]; then
   cd /home/vagrant/myconnectome
   $HOME/miniconda/bin/python /home/vagrant/myconnectome/setup.py install
 fi
 
-# Start the flask application via supervisor
+# Add the configuration to nginx sites enabled, to be run with gunicorn
 sudo ln -s /etc/nginx/sites-available/flask_project /etc/nginx/sites-enabled/flask_project
 cd /var/www
-sudo /etc/init.d/nginx restart
-sudo supervisorctl reread
-sudo supervisorctl update
-sudo supervisorctl start flask_project
-echo ""
-echo "Open your browser to 192.128.0.20:5000 to view analysis"
 
 # need to set the date properly in order for AWS up/downloads to work
 sudo ntpdate pool.ntp.org
@@ -153,6 +135,12 @@ if ! [ -f $HOME/myconnectome/.started ]; then
   sudo echo "$MYCONNECTOME_ID" >> /home/vagrant/myconnectome/.started
 fi
   
+# Start the application with gunicorn
+sudo /etc/init.d/nginx restart
+$HOME/miniconda/bin/gunicorn index:app -b 0.0.0.0:5000 &
+sudo /etc/init.d/nginx restart
+echo ""
+echo "Open your browser to 192.128.0.20:5000 to view analysis"
 
 SCRIPT
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,7 @@ rm /tmp/myppa.list
 
 sudo apt-get update > /dev/null
 sudo apt-get install -y --force-yes libicu48
-sudo apt-get install -y --force-yes r-base git connectome-workbench
+sudo apt-get install -y --force-yes git connectome-workbench
 sudo apt-get install -y --force-yes r-base
 sudo apt-get install -y --force-yes xserver-xorg-core
 
@@ -137,14 +137,17 @@ def show_analyses():
     meta_files =       [('/var/www/results/myconnectome/metabolomics/Metabolomics_clustering.html','Metabolomics data preparation'),
                         ('/var/www/results/myconnectome/metabolomics','Listing of all files')]
 
+    rsfmri_files = [('/var/www/results/myconnectome/rsfmri','Listing of all files')]
+
     # How many green links should we have?
-    number_analyses = len(meta_files) + len(rna_files) + len(timeseries_files)
+    number_analyses = len(meta_files) + len(rna_files) + len(timeseries_files) + len(rsfmri_files)
 
     # Check if the file exists, render context based on existence            
     counter = 0
     timeseries_context,counter = create_context(timeseries_files,counter)
     rna_context,counter = create_context(rna_files,counter)
     meta_context,counter = create_context(meta_files,counter)
+    rsfmri_context,counter = create_context(rsfmri_files,counter)
 
     # The counter determines if we've finished running analyses
     analysis_status = 'Analysis is Running'
@@ -162,7 +165,8 @@ def show_analyses():
     return render_template('index.html',timeseries_context=timeseries_context,
                                         rna_context=rna_context,
                                         meta_context=meta_context,
-                                        analysis_status=analysis_status)
+                                        analysis_status=analysis_status,
+                                        rsfmri_context=rsfmri_context)
 
 # Check if python process is still running
 def check_process():
@@ -273,6 +277,13 @@ if ! [ -f /var/www/templates/index.html ]; then
     	    <li><a href='{{ meta_url }}' style='{{ meta_style }}' title='{{ meta_title }}'>{{ meta_description }}</a></li>
             {% endfor %}		
 	</ul>  
+	<h2>Resting state fMRI analyses</h2>
+        <ul>
+            {% for rs_url, rs_description, rs_style, rs_title in rsfmri_context %}
+    	    <li><a href='{{ rs_url }}' style='{{ rs_style }}' title='{{ rs_title }}'>{{ rs_description }}</a></li>
+            {% endfor %}		
+	</ul>  
+
     </div><!-- End Right Box-->         
   </div>
 </div>


### PR DESCRIPTION
This will remove supervisor and run the application with standalone gunicorn. My understanding is that supervisor serves as a controller that would restart the application if the server goes down, and so in this case we would need to manually restart the application. When we consult OIT I would like to review this setup, and if they think it necessary to have a different controller, we can set something up. This seems like the best solution for the time being.
